### PR TITLE
Fix to_dict methods for Location and EmployeeTitle

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -13,9 +13,8 @@ class Location(Base):
 
     def to_dict(self):
         return {
-            'LocationID': self.LocationID,
-            'Address': self.Address,
-            'CareTakerID': self.CareTakerID
+            'id': self.id,
+            'name': self.name
         }
 
 
@@ -78,9 +77,8 @@ class EmployeeTitle(Base):
 
     def to_dict(self):
         return {
-            'EmployeeID': self.EmployeeID,
-            'FirstName': self.FirstName,
-            'LastName': self.LastName
+            'id': self.id,
+            'title': self.title
         }
 
 


### PR DESCRIPTION
## Summary
- Ensure Location.to_dict returns existing id and name fields
- Correct EmployeeTitle.to_dict to expose id and title

## Testing
- `python - <<'PY'
from backend.models import Location, EmployeeTitle, CoffeeMachines, Profile
print(Location(id=1, name='HQ').to_dict())
print(EmployeeTitle(id=2, title='Manager').to_dict())
print(CoffeeMachines(id=1, model='ModelX', location_id='Loc1', caretaker_id=2).to_dict())
print(Profile(id=1, name='Alice', position='Engineer', description='desc', profilePicture='pic.jpg').to_dict())
PY` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68b87f754d28832090bb7d4c4eb81a28